### PR TITLE
initWithCode method can now create a codable value properly

### DIFF
--- a/HVMobile_VNext-master/HVLib/Types/HVCodedValue.m
+++ b/HVMobile_VNext-master/HVLib/Types/HVCodedValue.m
@@ -33,7 +33,7 @@ static const xmlChar* x_element_version = XMLSTRINGCONST("version");
     self = [super init];
     HVCHECK_SELF;
     
-    self.code = code;
+    self.code = strcode;
     self.vocabularyName = vocab;
     if (family)
     {


### PR DESCRIPTION
The method did not assign the value given as an argument to the code property. It assigned the property to itself instead of the method argument.
